### PR TITLE
Add autofocus

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Every component will:
 - Have the base CSS class name `.ember-stripe-element`
 - Have a CSS class for the specific element that matches the component's name, e.g. `{{ember-stripe-card}}` has the class `.ember-stripe-card`
 - Yield to a block
+- Accept `autofocus=true` passed directly in the component, e.g. `{{stripe-card autofocus=true}}`
 
 > Every component extends from a `StripeElement` base component which is not exposed to your application.
 

--- a/addon/components/stripe-element.js
+++ b/addon/components/stripe-element.js
@@ -9,6 +9,8 @@ const {
 
 export default Component.extend({
   classNames: ['ember-stripe-element'],
+
+  autofocus: false,
   error: null,
   options: [],
   stripeElement: null,
@@ -38,6 +40,18 @@ export default Component.extend({
 
     // Set the event listeners
     this.setEventListeners();
+  },
+
+  didRender() {
+    this._super(...arguments);
+    // Fetch autofocus, set by user
+    let autofocus = get(this, 'autofocus');
+    let stripeElement = get(this, 'stripeElement');
+    if (autofocus) {
+      this.$('iframe')[0].onload = () => {
+        stripeElement.focus();
+      };
+    }
   },
 
   didUpdateAttrs() {

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -38,6 +38,7 @@ export default Controller.extend({
   options: {
     style
   },
+  
   actions: {
     submit(stripeElement) {
       let stripe = get(this, 'stripev3');

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -3,7 +3,7 @@
 </p>
 
 <div class="input-group">
-  {{#stripe-card options=cardOptions as |stripeElement error|}}
+  {{#stripe-card autofocus=true options=cardOptions as |stripeElement error|}}
     {{#if error}}
       <p class="error">{{error.message}}</p>
     {{/if}}


### PR DESCRIPTION
This adds the ability to do `{{stripe-card autofocus=true}}` by adding an `onload` listener to the Stripe `iframe` in `didRender`.