### PR TITLE
ability to share elements when using stripe-card-* components

### DIFF
--- a/addon/components/stripe-element.js
+++ b/addon/components/stripe-element.js
@@ -4,7 +4,8 @@ const {
   Component,
   get,
   inject: { service },
-  set
+  set,
+  computed,
 } = Ember;
 
 export default Component.extend({
@@ -17,11 +18,14 @@ export default Component.extend({
   type: null, // Set in components that extend from `stripe-element`
 
   stripev3: service(),
+  elements: computed(function() {
+    return get(this, 'stripev3.elements')();
+  }),
 
   didInsertElement() {
     this._super(...arguments);
 
-    let elements = get(this, 'stripev3.elements')();
+    let elements = get(this, 'elements');
 
     // Fetch user options
     let options = get(this, 'options');


### PR DESCRIPTION
`get(this, 'stripev3.elements')()` creates new instance each time it is called, so we need to share the same instance to track all standalone components, to get the toket we should use stripeElement for `cardNumber`
```
{{#stripe-card-number class="input" elements=cardElements as |element|}}
   
{{/stripe-card-number}}
{{stripe-card-expiry class="input" elements=cardElements}}
{{stripe-card-cvc class="input" elements=cardElements}}
```
and somewhere in parent component or controller 
```
cardElements: computed(function() {
    return get(this, 'stripeService').elements();
}),
```

ideally it can be wrapped in contextual parent component where `cardElements` will be created
