### PR TITLE
`options` should default to an empty object (fixes #20)

### DIFF
--- a/addon/components/stripe-element.js
+++ b/addon/components/stripe-element.js
@@ -7,7 +7,7 @@ export default Component.extend({
 
   autofocus: false,
   error: null,
-  options: [],
+  options: {},
   stripeElement: null,
   type: null, // Set in components that extend from `stripe-element`
 


### PR DESCRIPTION
This should resolve any issues where `options` is not overridden, causing exceptions with recent versions of Stripe.js.