### PR TITLE
[RFC] Allow the usage of separated stripe components to generate token

### DIFF
--- a/addon/components/stripe-element.js
+++ b/addon/components/stripe-element.js
@@ -19,8 +19,6 @@ export default Component.extend({
   didInsertElement() {
     this._super(...arguments);
 
-    let elements = get(this, 'stripev3.elements')();
-
     // Fetch user options
     let options = get(this, 'options');
 
@@ -28,7 +26,7 @@ export default Component.extend({
     let type = get(this, 'type');
 
     // `stripeElement` instead of `element` to distinguish from `this.element`
-    let stripeElement = elements.create(type, options);
+    let stripeElement = get(this, 'elements').create(type, options);
 
     // Mount the Stripe Element onto the mount point
     stripeElement.mount(this.element.querySelector('[role="mount-point"]'));


### PR DESCRIPTION
## Context

I've started using this addon but my use case is a bit different from the example described. We wanted to use each of the stripe components (card number, expiry and CVV) separately and then create a token using one these ```stripe elements```. Although the Stripe's documentation says that ```The Element pulls data from other Elements you’ve created on the same instance of elements to tokenize```, it didn't work because it considered just the element I was passing.

But there was an important part of the phrase that made me think, ```...you’ve created on the same instance of elements...```. After taking a look at the code, I've realized that each component was being created using a new instance of elements by calling ```get(this, 'stripev3.elements')()``` and consequently, the Stripe.js wasn't able to pull all the data because each of stripe components belonged to a different group.

This fix allows us to inject an ```elements``` from our application to the component so all of the stripe elements are created using the same instance and therefore Stripe.js knows how to pull the card information from all of them. 

I hope it can help people with the same use case :)








