### PR TITLE
Add functions missing from the Stripe object

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,21 @@ A simple Ember wrapper for [Stripe Elements](https://stripe.com/docs/elements).
 
 - Inject `<script src="https://js.stripe.com/v3/"></script>` into your application's `<body>`
 - Initialize `Stripe` with your publishable key
-- Inject a `stripev3` service into your controllers so you can use:
-  - [`stripe.createToken(element[, options])`](https://stripe.com/docs/elements/reference#stripe-create-token)
-  - [`stripe.createSource(element[, options])`](https://stripe.com/docs/elements/reference#stripe-create-source)
-  - [`stripe.retrieveSource(source)`](https://stripe.com/docs/elements/reference#stripe-retrieve-source)
-  - [`stripe.paymentRequest(options)`](https://stripe.com/docs/stripe-js/reference#stripe-payment-request)
-  - [`stripe.elements([options])`](https://stripe.com/docs/elements/reference#stripe-elements), if for some reason you need to
+- Inject a `stripev3` service into your controllers so you can use the functions usually available on the `stripe` object (see https://stripe.com/docs/stripe-js/reference#the-stripe-object):
+  - `stripe.elements()`
+  - `stripe.createToken()`
+  - `stripe.createSource()`
+  - `stripe.createPaymentMethod()`
+  - `stripe.retrieveSource()`
+  - `stripe.paymentRequest()`
+  - `stripe.redirectToCheckout()`
+  - `stripe.retrievePaymentIntent()`
+  - `stripe.handleCardPayment()`
+  - `stripe.handleCardAction()`
+  - `stripe.confirmPaymentIntent()`
+  - `stripe.handleCardSetup()`
+  - `stripe.retrieveSetupIntent()`
+  - `stripe.confirmSetupIntent()`
 - Simple, configurable Ember components like `{{stripe-card}}` (demoed in the gif above)
 
 ## Installation

--- a/addon/services/stripev3.js
+++ b/addon/services/stripev3.js
@@ -1,9 +1,27 @@
 /* global Stripe */
 import Service from '@ember/service';
-import { setProperties } from '@ember/object';
+import { getProperties, setProperties } from '@ember/object';
 import { readOnly } from '@ember/object/computed';
 import { resolve } from 'rsvp';
 import loadScript from 'ember-stripe-elements/utils/load-script';
+
+// As listed at https://stripe.com/docs/stripe-js/reference#the-stripe-object
+const STRIPE_FUNCTIONS = [
+  'elements',
+  'createToken',
+  'createSource',
+  'createPaymentMethod',
+  'retrieveSource',
+  'paymentRequest',
+	'redirectToCheckout',
+	'retrievePaymentIntent',
+	'handleCardPayment',
+	'handleCardAction',
+	'confirmPaymentIntent',
+	'handleCardSetup',
+	'retrieveSetupIntent',
+	'confirmSetupIntent'
+];
 
 export default Service.extend({
   config: null,
@@ -44,8 +62,10 @@ export default Service.extend({
     if (!didConfigure) {
       let publishableKey = this.get('publishableKey');
 
-      let { elements, createToken, createSource, retrieveSource, paymentRequest, createPaymentMethod } = new Stripe(publishableKey);
-      setProperties(this, { elements, createToken, createSource, retrieveSource, paymentRequest, createPaymentMethod });
+
+      let stripe = new Stripe(publishableKey);
+      let functions = getProperties(stripe, STRIPE_FUNCTIONS);
+      setProperties(this, functions);
 
       this.set('didConfigure', true);
     }

--- a/addon/utils/stripe-mock.js
+++ b/addon/utils/stripe-mock.js
@@ -13,9 +13,18 @@ StripeMock.prototype.elements = function() {
     }
   };
 }
-StripeMock.prototype.createToken = function() {}
-StripeMock.prototype.createSource = function() {}
-StripeMock.prototype.retrieveSource = function() {}
-StripeMock.prototype.paymentRequest = function() {}
+StripeMock.prototype.createToken = function() {};
+StripeMock.prototype.createSource = function() {};
+StripeMock.prototype.createPaymentMethod = function() {};
+StripeMock.prototype.retrieveSource = function() {};
+StripeMock.prototype.paymentRequest = function() {};
+StripeMock.prototype.redirectToCheckout = function() {};
+StripeMock.prototype.retrievePaymentIntent = function() {};
+StripeMock.prototype.handleCardPayment = function() {};
+StripeMock.prototype.handleCardAction = function() {};
+StripeMock.prototype.confirmPaymentIntent = function() {};
+StripeMock.prototype.handleCardSetup = function() {};
+StripeMock.prototype.retrieveSetupIntent = function() {};
+StripeMock.prototype.confirmSetupIntent = function() {};
 
 export default StripeMock;

--- a/tests/unit/services/stripev3-test.js
+++ b/tests/unit/services/stripev3-test.js
@@ -100,5 +100,116 @@ module('Unit | Service | stripev3', function(hooks) {
     paymentRequest(mockOptions);
     paymentRequest.restore();
   });
-});
 
+  test('makes Stripe.redirectToCheckout available on the service', function(assert) {
+    assert.expect(1);
+
+    let service = this.subject;
+    let mockOptions = { locale: 'en' };
+
+    let redirectToCheckout = sinon.stub(service, 'redirectToCheckout').callsFake(function(options) {
+      assert.deepEqual(options, mockOptions, 'called with mock options');
+    });
+
+    redirectToCheckout(mockOptions);
+    redirectToCheckout.restore();
+  });
+
+  test('makes Stripe.retrievePaymentIntent available on the service', function(assert) {
+    assert.expect(1);
+
+    let service = this.subject;
+    let mockOptions = { locale: 'en' };
+
+    let retrievePaymentIntent = sinon.stub(service, 'retrievePaymentIntent').callsFake(function(options) {
+      assert.deepEqual(options, mockOptions, 'called with mock options');
+    });
+
+    retrievePaymentIntent(mockOptions);
+    retrievePaymentIntent.restore();
+  });
+
+  test('makes Stripe.handleCardPayment available on the service', function(assert) {
+    assert.expect(1);
+
+    let service = this.subject;
+    let mockOptions = { locale: 'en' };
+
+    let handleCardPayment = sinon.stub(service, 'handleCardPayment').callsFake(function(options) {
+      assert.deepEqual(options, mockOptions, 'called with mock options');
+    });
+
+    handleCardPayment(mockOptions);
+    handleCardPayment.restore();
+  });
+
+  test('makes Stripe.handleCardAction available on the service', function(assert) {
+    assert.expect(1);
+
+    let service = this.subject;
+    let mockOptions = { locale: 'en' };
+
+    let handleCardAction = sinon.stub(service, 'handleCardAction').callsFake(function(options) {
+      assert.deepEqual(options, mockOptions, 'called with mock options');
+    });
+
+    handleCardAction(mockOptions);
+    handleCardAction.restore();
+  });
+
+  test('makes Stripe.confirmPaymentIntent available on the service', function(assert) {
+    assert.expect(1);
+
+    let service = this.subject;
+    let mockOptions = { locale: 'en' };
+
+    let confirmPaymentIntent = sinon.stub(service, 'confirmPaymentIntent').callsFake(function(options) {
+      assert.deepEqual(options, mockOptions, 'called with mock options');
+    });
+
+    confirmPaymentIntent(mockOptions);
+    confirmPaymentIntent.restore();
+  });
+
+  test('makes Stripe.handleCardSetup available on the service', function(assert) {
+    assert.expect(1);
+
+    let service = this.subject;
+    let mockOptions = { locale: 'en' };
+
+    let handleCardSetup = sinon.stub(service, 'handleCardSetup').callsFake(function(options) {
+      assert.deepEqual(options, mockOptions, 'called with mock options');
+    });
+
+    handleCardSetup(mockOptions);
+    handleCardSetup.restore();
+  });
+
+  test('makes Stripe.retrieveSetupIntent available on the service', function(assert) {
+    assert.expect(1);
+
+    let service = this.subject;
+    let mockOptions = { locale: 'en' };
+
+    let retrieveSetupIntent = sinon.stub(service, 'retrieveSetupIntent').callsFake(function(options) {
+      assert.deepEqual(options, mockOptions, 'called with mock options');
+    });
+
+    retrieveSetupIntent(mockOptions);
+    retrieveSetupIntent.restore();
+  });
+
+  test('makes Stripe.confirmSetupIntent available on the service', function(assert) {
+    assert.expect(1);
+
+    let service = this.subject;
+    let mockOptions = { locale: 'en' };
+
+    let confirmSetupIntent = sinon.stub(service, 'confirmSetupIntent').callsFake(function(options) {
+      assert.deepEqual(options, mockOptions, 'called with mock options');
+    });
+
+    confirmSetupIntent(mockOptions);
+    confirmSetupIntent.restore();
+  });
+});

--- a/tests/unit/services/stripev3-test.js
+++ b/tests/unit/services/stripev3-test.js
@@ -59,6 +59,20 @@ module('Unit | Service | stripev3', function(hooks) {
     createSource.restore();
   });
 
+  test('makes Stripe.createPaymentMethod available on the service', function(assert) {
+    assert.expect(1);
+
+    let service = this.subject;
+    let mockOptions = { locale: 'en' };
+
+    let createPaymentMethod = sinon.stub(service, 'createPaymentMethod').callsFake(function(options) {
+      assert.deepEqual(options, mockOptions, 'called with mock options');
+    });
+
+    createPaymentMethod(mockOptions);
+    createPaymentMethod.restore();
+  });
+
   test('makes Stripe.retrieveSource available on the service', function(assert) {
     assert.expect(1);
 


### PR DESCRIPTION
Today I needed `stripe.createPaymentMethod()` and `stripe.handleCardAction()`. The first one was on `develop`, just not on the published package. The second one wasn't there at all.

While looking into it, I realised that there were several other functions missing, so here I'm adding them all, as currently listed at https://stripe.com/docs/stripe-js/reference#the-stripe-object.