### PR TITLE
Fix build

### DIFF
--- a/addon/components/stripe-element.js
+++ b/addon/components/stripe-element.js
@@ -6,10 +6,15 @@ export default Component.extend({
   classNames: ['ember-stripe-element'],
 
   autofocus: false,
-  options: computed(() => ({})),
+  options: null,
   stripeElement: null,
   stripeError: null,
   type: null, // Set in components that extend from `stripe-element`
+
+  init() {
+    this._super(...arguments);
+    set(this, 'options', {});
+  },
 
   stripev3: service(),
   elements: computed(function() {

--- a/addon/components/stripe-element.js
+++ b/addon/components/stripe-element.js
@@ -6,7 +6,7 @@ export default Component.extend({
   classNames: ['ember-stripe-element'],
 
   autofocus: false,
-  options: {},
+  options: computed(() => ({})),
   stripeElement: null,
   stripeError: null,
   type: null, // Set in components that extend from `stripe-element`

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,7 +5,9 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
-    // Add options here
+    'ember-cli-babel': {
+      includePolyfill: true,
+    }
   });
 
   /*

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
-import { get, set } from '@ember/object';
+import { computed, get, set } from '@ember/object';
 
 let style = {
   style: {
@@ -25,14 +25,14 @@ export default Controller.extend({
 
   token: null,
 
-  cardOptions: {
+  cardOptions: computed(() => ({
     hidePostalCode: true,
     style
-  },
+  })),
 
-  options: {
+  options: computed(() => ({
     style
-  },
+  })),
 
   actions: {
     submit(stripeElement) {

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
-import { computed, get, set } from '@ember/object';
+import { get, set } from '@ember/object';
 
 let style = {
   style: {
@@ -24,15 +24,14 @@ export default Controller.extend({
   stripev3: service(),
 
   token: null,
+  cardOptions: null,
+  options: null,
 
-  cardOptions: computed(() => ({
-    hidePostalCode: true,
-    style
-  })),
-
-  options: computed(() => ({
-    style
-  })),
+  init() {
+    this._super(...arguments);
+    set(this, 'cardOptions', { hidePostalCode: true, style });
+    set(this, 'options', { style });
+  },
 
   actions: {
     submit(stripeElement) {

--- a/tests/integration/components/stripe-card-cvc-test.js
+++ b/tests/integration/components/stripe-card-cvc-test.js
@@ -1,25 +1,31 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { render } from '@ember/test-helpers';
 import StripeMock from 'ember-stripe-elements/utils/stripe-mock';
 import env from 'dummy/config/environment';
+import StripeService from 'dummy/services/stripev3';
 
-moduleForComponent('stripe-card-cvc', 'Integration | Component | stripe card cvc', {
-  integration: true,
-  beforeEach() {
+module('Integration | Component | stripe card cvc', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
     window.Stripe = StripeMock;
-
-    let config = {
+    const config = {
       mock: true,
-      publishableKey: env.stripe.publishableKey
+      publishableKey: env.stripe.publishableKey,
     };
 
-    this.register('config:stripe', config, { instantiate: false });
-    this.inject.service('stripev3', 'config', 'config:stripe');
-  }
-});
+    this.owner.register(
+      'service:stripev3',
+      StripeService.create({ config }),
+      { instantiate: false }
+    );
+  });
 
-test('it renders', function(assert) {
-  this.render(hbs`{{stripe-card-cvc}}`);
+  test('it renders', async function(assert) {
+    await render(hbs`{{stripe-card-cvc}}`);
 
-  assert.equal(this.$().text().trim(), '');
+    assert.equal(this.element.textContent.trim(), '');
+  });
 });

--- a/tests/integration/components/stripe-card-expiry-test.js
+++ b/tests/integration/components/stripe-card-expiry-test.js
@@ -1,25 +1,31 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { render } from '@ember/test-helpers';
 import StripeMock from 'ember-stripe-elements/utils/stripe-mock';
 import env from 'dummy/config/environment';
+import StripeService from 'dummy/services/stripev3';
 
-moduleForComponent('stripe-card-expiry', 'Integration | Component | stripe card expiry', {
-  integration: true,
-  beforeEach() {
+module('Integration | Component | stripe card expiry', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
     window.Stripe = StripeMock;
-
-    let config = {
+    const config = {
       mock: true,
-      publishableKey: env.stripe.publishableKey
+      publishableKey: env.stripe.publishableKey,
     };
 
-    this.register('config:stripe', config, { instantiate: false });
-    this.inject.service('stripev3', 'config', 'config:stripe');
-  }
-});
+    this.owner.register(
+      'service:stripev3',
+      StripeService.create({ config }),
+      { instantiate: false }
+    );
+  });
 
-test('it renders', function(assert) {
-  this.render(hbs`{{stripe-card-expiry}}`);
+  test('it renders', async function(assert) {
+    await render(hbs`{{stripe-card-expiry}}`);
 
-  assert.equal(this.$().text().trim(), '');
+    assert.equal(this.element.textContent.trim(), '');
+  });
 });

--- a/tests/integration/components/stripe-card-number-test.js
+++ b/tests/integration/components/stripe-card-number-test.js
@@ -1,25 +1,32 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { render } from '@ember/test-helpers';
 import StripeMock from 'ember-stripe-elements/utils/stripe-mock';
 import env from 'dummy/config/environment';
+import StripeService from 'dummy/services/stripev3';
 
-moduleForComponent('stripe-card-number', 'Integration | Component | stripe card number', {
-  integration: true,
-  beforeEach() {
+module('Integration | Component | stripe card number', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
     window.Stripe = StripeMock;
-
-    let config = {
+    const config = {
       mock: true,
-      publishableKey: env.stripe.publishableKey
+      publishableKey: env.stripe.publishableKey,
     };
 
-    this.register('config:stripe', config, { instantiate: false });
-    this.inject.service('stripev3', 'config', 'config:stripe');
-  }
+    this.owner.register(
+      'service:stripev3',
+      StripeService.create({ config }),
+      { instantiate: false }
+    );
+  });
+
+  test('it renders', async function(assert) {
+    await render(hbs`{{stripe-card-number}}`);
+
+    assert.equal(this.element.textContent.trim(), '');
+  });
 });
 
-test('it renders', function(assert) {
-  this.render(hbs`{{stripe-card-number}}`);
-
-  assert.equal(this.$().text().trim(), '');
-});

--- a/tests/integration/components/stripe-card-test.js
+++ b/tests/integration/components/stripe-card-test.js
@@ -1,41 +1,47 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { render } from '@ember/test-helpers';
 import StripeMock from 'ember-stripe-elements/utils/stripe-mock';
 import env from 'dummy/config/environment';
+import StripeService from 'dummy/services/stripev3';
 
-moduleForComponent('stripe-card', 'Integration | Component | stripe card', {
-  integration: true,
-  beforeEach() {
+module('Integration | Component | stripe card', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
     window.Stripe = StripeMock;
-
-    let config = {
+    const config = {
       mock: true,
-      publishableKey: env.stripe.publishableKey
+      publishableKey: env.stripe.publishableKey,
     };
 
-    this.register('config:stripe', config, { instantiate: false });
-    this.inject.service('stripev3', 'config', 'config:stripe');
-  }
-});
+    this.owner.register(
+      'service:stripev3',
+      StripeService.create({ config }),
+      { instantiate: false }
+    );
+  });
 
-test('it renders', function(assert) {
-  // Template block usage:
-  this.render(hbs`
-    {{#stripe-card}}
-      template block text
-    {{/stripe-card}}
-  `);
+  test('it renders', async function(assert) {
+    // Template block usage:
+    await render(hbs`
+      {{#stripe-card}}
+        template block text
+      {{/stripe-card}}
+    `);
 
-  assert.equal(this.$().text().trim(), 'template block text');
-});
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
 
-test('yields out error message', function(assert) {
-  this.stripeError = { message: 'oops' };
-  this.render(hbs`
-    {{#stripe-card stripeError=stripeError as |stripeElement stripeError|}}
-      {{stripeError.message}}
-    {{/stripe-card}}
-  `);
+  test('yields out error message', async function(assert) {
+    this.stripeError = { message: 'oops' };
+    await this.render(hbs`
+      {{#stripe-card stripeError=stripeError as |stripeElement stripeError|}}
+        {{stripeError.message}}
+      {{/stripe-card}}
+    `);
 
-  assert.equal(this.$().text().trim(), 'oops');
+    assert.equal(this.element.textContent.trim(), 'oops');
+  });
 });

--- a/tests/integration/components/stripe-postal-code-test.js
+++ b/tests/integration/components/stripe-postal-code-test.js
@@ -1,25 +1,31 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { render } from '@ember/test-helpers';
 import StripeMock from 'ember-stripe-elements/utils/stripe-mock';
 import env from 'dummy/config/environment';
+import StripeService from 'dummy/services/stripev3';
 
-moduleForComponent('stripe-postal-code', 'Integration | Component | stripe postal code', {
-  integration: true,
-  beforeEach() {
+module('Integration | Component | stripe postal code', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
     window.Stripe = StripeMock;
-
-    let config = {
+    const config = {
       mock: true,
-      publishableKey: env.stripe.publishableKey
+      publishableKey: env.stripe.publishableKey,
     };
 
-    this.register('config:stripe', config, { instantiate: false });
-    this.inject.service('stripev3', 'config', 'config:stripe');
-  }
-});
+    this.owner.register(
+      'service:stripev3',
+      StripeService.create({ config }),
+      { instantiate: false }
+    );
+  });
 
-test('it renders', function(assert) {
-  this.render(hbs`{{stripe-postal-code}}`);
+  test('it renders', async function(assert) {
+    await render(hbs`{{stripe-postal-code}}`);
 
-  assert.equal(this.$().text().trim(), '');
+    assert.equal(this.element.textContent.trim(), '');
+  });
 });

--- a/tests/unit/services/stripev3-test.js
+++ b/tests/unit/services/stripev3-test.js
@@ -1,89 +1,90 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 import StripeMock from 'ember-stripe-elements/utils/stripe-mock';
 import env from 'dummy/config/environment';
 
-moduleFor('service:stripev3', 'Unit | Service | stripev3', {
-  // Specify the other units that are required for this test.
-  needs: ['config:environment'],
-  beforeEach() {
-    window.Stripe = StripeMock;
+module('Unit | Service | stripev3', function(hooks) {
+  setupTest(hooks);
 
-    this.stripe = this.subject({
+  hooks.beforeEach(function() {
+    window.Stripe = StripeMock;
+    this.subject = this.owner.factoryFor('service:stripev3').create({
       config: {
         mock: true,
         publishableKey: env.stripe.publishableKey
       }
     });
-  }
-});
-
-test('makes Stripe.elements available on the service', function(assert) {
-  assert.expect(1);
-
-  let service = this.subject();
-  let mockOptions = { locale: 'en' };
-
-  let elements = sinon.stub(service, 'elements').callsFake(function(options) {
-    assert.deepEqual(options, mockOptions, 'called with mock options');
   });
 
-  elements(mockOptions);
-  elements.restore();
-});
+  test('makes Stripe.elements available on the service', function(assert) {
+    assert.expect(1);
 
-test('makes Stripe.createToken available on the service', function(assert) {
-  assert.expect(1);
+    let service = this.subject;
+    let mockOptions = { locale: 'en' };
 
-  let service = this.subject();
-  let mockOptions = { locale: 'en' };
+    let elements = sinon.stub(service, 'elements').callsFake(function(options) {
+      assert.deepEqual(options, mockOptions, 'called with mock options');
+    });
 
-  let createToken = sinon.stub(service, 'createToken').callsFake(function(options) {
-    assert.deepEqual(options, mockOptions, 'called with mock options');
+    elements(mockOptions);
+    elements.restore();
   });
 
-  createToken(mockOptions);
-  createToken.restore();
-});
+  test('makes Stripe.createToken available on the service', function(assert) {
+    assert.expect(1);
 
-test('makes Stripe.createSource available on the service', function(assert) {
-  assert.expect(1);
+    let service = this.subject;
+    let mockOptions = { locale: 'en' };
 
-  let service = this.subject();
-  let mockOptions = { locale: 'en' };
+    let createToken = sinon.stub(service, 'createToken').callsFake(function(options) {
+      assert.deepEqual(options, mockOptions, 'called with mock options');
+    });
 
-  let createSource = sinon.stub(service, 'createSource').callsFake(function(options) {
-    assert.deepEqual(options, mockOptions, 'called with mock options');
+    createToken(mockOptions);
+    createToken.restore();
   });
 
-  createSource(mockOptions);
-  createSource.restore();
-});
+  test('makes Stripe.createSource available on the service', function(assert) {
+    assert.expect(1);
 
-test('makes Stripe.retrieveSource available on the service', function(assert) {
-  assert.expect(1);
+    let service = this.subject;
+    let mockOptions = { locale: 'en' };
 
-  let service = this.subject();
-  let mockOptions = { locale: 'en' };
+    let createSource = sinon.stub(service, 'createSource').callsFake(function(options) {
+      assert.deepEqual(options, mockOptions, 'called with mock options');
+    });
 
-  let retrieveSource = sinon.stub(service, 'retrieveSource').callsFake(function(options) {
-    assert.deepEqual(options, mockOptions, 'called with mock options');
+    createSource(mockOptions);
+    createSource.restore();
   });
 
-  retrieveSource(mockOptions);
-  retrieveSource.restore();
-});
+  test('makes Stripe.retrieveSource available on the service', function(assert) {
+    assert.expect(1);
 
-test('makes Stripe.paymentRequest available on the service', function(assert) {
-  assert.expect(1);
+    let service = this.subject;
+    let mockOptions = { locale: 'en' };
 
-  let service = this.subject();
-  let mockOptions = { locale: 'en' };
+    let retrieveSource = sinon.stub(service, 'retrieveSource').callsFake(function(options) {
+      assert.deepEqual(options, mockOptions, 'called with mock options');
+    });
 
-  let paymentRequest = sinon.stub(service, 'paymentRequest').callsFake(function(options) {
-    assert.deepEqual(options, mockOptions, 'called with mock options');
+    retrieveSource(mockOptions);
+    retrieveSource.restore();
   });
 
-  paymentRequest(mockOptions);
-  paymentRequest.restore();
+  test('makes Stripe.paymentRequest available on the service', function(assert) {
+    assert.expect(1);
+
+    let service = this.subject;
+    let mockOptions = { locale: 'en' };
+
+    let paymentRequest = sinon.stub(service, 'paymentRequest').callsFake(function(options) {
+      assert.deepEqual(options, mockOptions, 'called with mock options');
+    });
+
+    paymentRequest(mockOptions);
+    paymentRequest.restore();
+  });
 });
+


### PR DESCRIPTION
As mentioned at https://github.com/code-corps/ember-stripe-elements/pull/50, something has changed that has broken the build. I don't know what, as the latest commit on `develop` passed the build.

In any case, this fixes the build. It involved:

* Fixing some linter warnings.
* Changing the way a mock service is injected into tests. The existing strategy was not supported in Canary.