### PR TITLE
Never configure the service on init if lazyLoad is enabled

### DIFF
--- a/addon/services/stripev3.js
+++ b/addon/services/stripev3.js
@@ -36,9 +36,8 @@ export default Service.extend({
     this._super(...arguments);
 
     let lazyLoad = this.get('lazyLoad');
-    let mock = this.get('mock');
 
-    if (!lazyLoad || mock) {
+    if (!lazyLoad) {
       this.configure();
     }
   },


### PR DESCRIPTION
Fixes #58 

In cases where lazyLoad and mock are both enabled, the service should get configured in the load method instead of in the init hook. 