### PR TITLE
Update Readme to mention develop branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ A simple Ember wrapper for [Stripe Elements](https://stripe.com/docs/elements).
 $ ember install ember-stripe-elements
 ```
 
+Note if you want to use all the functions for v3 (e.g. `handleCardPayment()`) you need to be using the develop branch after installing add this to your `package.json`
+
+```json
+  "dependencies": {
+    "ember-stripe-elements": "code-corps/ember-stripe-elements#develop"
+  }
+```
+
 ## Compatibility
 
 * Ember.js v2.18 or above


### PR DESCRIPTION
Hey,

I don't know if this is the right way to do it, but I lost a bit of time trying to figure out why the functions I needed were not on the `stripe` service. I figured out it was because I needed to be using the develop branch.

So I added a note on the install step for people that want to use those functions.