### PR TITLE
Update handleCardSetup()

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A simple Ember wrapper for [Stripe Elements](https://stripe.com/docs/elements).
   - `stripe.handleCardAction()`
   - `stripe.confirmPaymentIntent()`
   - `stripe.handleCardSetup()`
+  - `stripe.confirmCardSetup()`
   - `stripe.retrieveSetupIntent()`
   - `stripe.confirmSetupIntent()`
 - Simple, configurable Ember components like `{{stripe-card}}` (demoed in the gif above)

--- a/addon/services/stripev3.js
+++ b/addon/services/stripev3.js
@@ -19,7 +19,8 @@ const STRIPE_FUNCTIONS = [
 	'handleCardPayment',
 	'handleCardAction',
 	'confirmPaymentIntent',
-	'handleCardSetup',
+  'handleCardSetup',
+  'confirmCardSetup',
 	'retrieveSetupIntent',
 	'confirmSetupIntent'
 ];

--- a/addon/utils/stripe-mock.js
+++ b/addon/utils/stripe-mock.js
@@ -24,6 +24,7 @@ StripeMock.prototype.handleCardPayment = function() {};
 StripeMock.prototype.handleCardAction = function() {};
 StripeMock.prototype.confirmPaymentIntent = function() {};
 StripeMock.prototype.handleCardSetup = function() {};
+StripeMock.prototype.confirmCardSetup = function() {};
 StripeMock.prototype.retrieveSetupIntent = function() {};
 StripeMock.prototype.confirmSetupIntent = function() {};
 

--- a/tests/unit/services/stripev3-test.js
+++ b/tests/unit/services/stripev3-test.js
@@ -185,6 +185,20 @@ module('Unit | Service | stripev3', function(hooks) {
     handleCardSetup.restore();
   });
 
+  test('makes Stripe.confirmCardSetup available on the service', function(assert) {
+    assert.expect(1);
+
+    let service = this.subject;
+    let mockOptions = { locale: 'en' };
+
+    let confirmCardSetup = sinon.stub(service, 'confirmCardSetup').callsFake(function(options) {
+      assert.deepEqual(options, mockOptions, 'called with mock options');
+    });
+
+    confirmCardSetup(mockOptions);
+    confirmCardSetup.restore();
+  });
+
   test('makes Stripe.retrieveSetupIntent available on the service', function(assert) {
     assert.expect(1);
 


### PR DESCRIPTION
- Stripe deprecated handleCardSetup() https://stripe.com/docs/stripe-js/reference#deprecated
- Looks like you now need to use confirmCardSetup() for the same thing https://stripe.com/docs/stripe-js/reference#stripe-confirm-card-setup

There probably are more depreciations, but this is the one that I was using, so I noticed it had broken.

I just did a find a replace, not overthinking, but it works in my app and the tests pass 💆‍♂️